### PR TITLE
Configuration support via file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustyline = { version = "9.0.0", optional = true }
 colored = "2.0.0"
+rustyline = { version = "9.0.0", optional = true }
+serde = { version = "1.0", features = ["derive"]}
+serde-lexpr = "0.1.0"
 
 [features]
 default = ["readline"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ fn process_input(shell_state: &mut ShellState, input: String) {
 
 #[cfg(feature = "readline")]
 fn main() {
-    let mut shell_state = ShellState::init();
+    let (mut shell_state, shell_config) = ShellState::init();
+    println!("{:#?}", shell_config);
     non_interactive(&mut shell_state);
     let mut rl = Editor::<()>::new();
     let history_file = [shell_state.share_dir.as_str(), "/crusty.history"].concat();


### PR DESCRIPTION
This will be a draft PR keeping track of configuration support.
Currently, I have it set up to parse lisp configuration.

Wanted features before merging:
- [ ] configuration options for:
  + [ ] making all parent directories if non-existant for redirections
  + [ ] prompt (this might be a whole separate PR though lol, unsure for now)
- [ ] ini configuration
- [ ] lisp configuration
- [ ] toml configuration