### PR TITLE
Fix for #28

### DIFF
--- a/src/builtins/calc.rs
+++ b/src/builtins/calc.rs
@@ -5,9 +5,7 @@ use crate::shared_functions::{get_calc_vars, is_piped};
 /// returning a String with the result.
 pub fn calc(args: Vec<String>) -> String {
     let mut output = String::new();
-    if is_piped(&args, "calc") {
-        return String::new();
-    }
+    is_piped(&args, "calc");
     let problem = args.concat();
     let (math_op, first_number, second_number) = get_calc_vars(&problem);
     match math_op {

--- a/src/builtins/echo.rs
+++ b/src/builtins/echo.rs
@@ -3,9 +3,7 @@ use crate::shared_functions::is_piped;
 /// Just like you know it. Takes the args part of ShellCommand and prints them.
 pub fn echo(args: Vec<String>) -> String {
     let mut output = String::new();
-    if is_piped(&args, "echo") {
-        return String::new();
-    }
+    is_piped(&args, "echo");
     for arg in args {
         output.push_str(format!("{} ", arg).as_str());
     }

--- a/src/builtins/ls.rs
+++ b/src/builtins/ls.rs
@@ -7,9 +7,7 @@ pub fn ls(mut args: Vec<String>) -> String {
     if args.is_empty() {
         args.push(".".to_string());
     }
-    if is_piped(&args, "ls") {
-        return String::new();
-    }
+    is_piped(&args, "ls");
     let mut path_idx = 0;
     for (idx, arg) in args.iter().enumerate() {
         if !arg.starts_with("--") || !arg.starts_with('-') {

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -379,24 +379,21 @@ pub fn parse_input(op: &str) -> String {
 
 /// This is a function for checking if the command is piped.
 /// Used to remove a lot of duplicate code.
-pub fn is_piped(args: &[String], cmd: &str) -> bool {
+pub fn is_piped(args: &[String], cmd: &str) {
     if args.contains(&"|".to_string()) {
         let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::NoOp);
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);
-        true
     } else if args.contains(&">>".to_string()) {
         let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::Append);
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);
-        true
     } else if args.contains(&">".to_string()) {
         let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::Overwrite);
         let pipe = PipedShellCommand::from(command);
         piped_cmd(pipe);
-        true
     } else {
-        false
+        // Do nothing.
     }
 }
 

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -242,21 +242,23 @@ impl ShellCommand {
     /// It is prefered that they return a string, which gets printed here,
     /// and not by the actual function, to make testing easier.
     pub fn run(shell_state: &mut ShellState, command: ShellCommand) {
-        match command.name.as_str() {
-            "calc" => println!("{}", calc(command.args)),
-            "cat" => println!("{}", cat(command.args)),
-            "cd" => cd(shell_state, command),
-            "echo" => println!("{}", echo(command.args)),
-            "help" => help(command.args),
-            "ls" => print!("{}", ls(command.args)),
-            "pwd" => println!("{}", std::env::current_dir().unwrap().display()),
-            _ => {
-                if command.args.contains(&String::from("|"))
-                    || command.args.contains(&String::from(">>"))
-                    || command.args.contains(&String::from(">"))
-                {
-                    piped_cmd(PipedShellCommand::from(command));
-                } else {
+        // check for piping first, because otherwise redirecting builtins
+        // would match the builtin and piping
+        if command.args.contains(&String::from("|"))
+            || command.args.contains(&String::from(">>"))
+            || command.args.contains(&String::from(">"))
+        {
+            piped_cmd(PipedShellCommand::from(command));
+        } else {
+            match command.name.as_str() {
+                "calc" => println!("{}", calc(command.args)),
+                "cat" => println!("{}", cat(command.args)),
+                "cd" => cd(shell_state, command),
+                "echo" => println!("{}", echo(command.args)),
+                "help" => help(command.args),
+                "ls" => print!("{}", ls(command.args)),
+                "pwd" => println!("{}", std::env::current_dir().unwrap().display()),
+                _ => {
                     print!("{}", cmd(command));
                 }
             }

--- a/src/shared_functions.rs
+++ b/src/shared_functions.rs
@@ -244,18 +244,18 @@ impl ShellCommand {
             || command.args.contains(&String::from(">>"))
             || command.args.contains(&String::from(">"))
         {
-            piped_cmd(PipedShellCommand::from(command));
+            piped_cmd(&PipedShellCommand::from(&command));
         } else {
             match command.name.as_str() {
-                "calc" => println!("{}", calc(command.args)),
-                "cat" => println!("{}", cat(command.args)),
-                "cd" => cd(shell_state, command),
-                "echo" => println!("{}", echo(command.args)),
-                "help" => help(command.args),
+                "calc" => println!("{}", calc(&command.args)),
+                "cat" => println!("{}", cat(&command.args)),
+                "cd" => cd(shell_state, &command),
+                "echo" => println!("{}", echo(&command.args)),
+                "help" => help(&command.args),
                 "ls" => print!("{}", ls(command.args)),
                 "pwd" => println!("{}", std::env::current_dir().unwrap().display()),
                 _ => {
-                    print!("{}", cmd(command));
+                    print!("{}", cmd(&command));
                 }
             }
         }
@@ -376,18 +376,17 @@ pub fn parse_input(op: &str) -> String {
 /// This is a function for checking if the command is piped.
 /// Used to remove a lot of duplicate code.
 pub fn is_piped(args: &[String], cmd: &str) {
+    fn run_pipe(cmd: &str, args: &[String], redirection: Redirection) {
+        let command = return_shellcommand(cmd.to_string(), args.to_vec(), redirection);
+        let pipe = PipedShellCommand::from(&command);
+        piped_cmd(&pipe);
+    }
     if args.contains(&"|".to_string()) {
-        let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::NoOp);
-        let pipe = PipedShellCommand::from(command);
-        piped_cmd(pipe);
+        run_pipe(cmd, args, Redirection::NoOp);
     } else if args.contains(&">>".to_string()) {
-        let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::Append);
-        let pipe = PipedShellCommand::from(command);
-        piped_cmd(pipe);
+        run_pipe(cmd, args, Redirection::Append);
     } else if args.contains(&">".to_string()) {
-        let command = return_shellcommand(cmd.to_string(), args.to_vec(), Redirection::Overwrite);
-        let pipe = PipedShellCommand::from(command);
-        piped_cmd(pipe);
+        run_pipe(cmd, args, Redirection::Overwrite);
     } else {
         // Do nothing.
     }


### PR DESCRIPTION
This fixes #28.
Builtins got run, eventhough redirection was specified, this was, because the match statement in `run()` first matched the builtins and then the redirection. With this fix, the previous isn't needed anymore and thus was reverted.